### PR TITLE
pocket_lab: '_available' attribute fixes and adapting to recent lvgl changes

### DIFF
--- a/pocket_lab/pl_gui_iio_wrapper.h
+++ b/pocket_lab/pl_gui_iio_wrapper.h
@@ -37,22 +37,18 @@ int32_t pl_gui_get_chn_unit(char *chn_unit, uint32_t chn_indx,
 int32_t pl_gui_get_global_attr_names(char *attr_names, uint32_t dev_indx);
 int32_t pl_gui_get_chn_attr_names(char *attr_names, uint32_t chn_indx,
 				  uint32_t dev_indx);
-int32_t pl_gui_scan_global_attr_avail_options(const char *attr_name,
+int32_t pl_gui_get_global_attr_avail_options(const char *attr_name,
 		char *attr_val, uint32_t dev_indx);
-int32_t pl_gui_scan_chn_attr_avail_options(const char *attr_name,
+int32_t pl_gui_get_chn_attr_avail_options(const char *attr_name,
 		char *attr_val, uint32_t chn_indx, uint32_t dev_indx);
-int32_t pl_gui_get_dev_attr_index(const char *attr_name, uint32_t *attr_indx,
-				  uint32_t dev_indx);
-int32_t pl_gui_get_chn_attr_index(const char *attr_name, uint32_t *attr_indx,
-				  uint32_t chn_indx, uint32_t dev_indx);
 int32_t pl_gui_read_global_attr(const char *attr_name, char *attr_val,
-				uint32_t attr_indx, uint32_t dev_indx);
-int32_t pl_gui_read_chn_attr(char *attr_val, uint32_t attr_indx,
+				uint32_t dev_indx);
+int32_t pl_gui_read_chn_attr(char *attr_name, char *attr_val,
 			     uint32_t chn_indx, uint32_t dev_indx);
 int32_t pl_gui_write_global_attr(const char *attr_name, char *attr_val,
-				 uint32_t attr_indx, uint32_t dev_indx);
+				 uint32_t dev_indx);
 int32_t pl_gui_write_chn_attr(const char *attr_name, char *attr_val,
-			      uint32_t attr_indx, uint32_t chn_indx, uint32_t dev_indx);
+			      uint32_t chn_indx, uint32_t dev_indx);
 int32_t pl_gui_read_reg(uint32_t addr, uint32_t *data, uint32_t dev_indx);
 int32_t pl_gui_write_reg(uint32_t addr, uint32_t data, uint32_t dev_indx);
 int32_t pl_gui_get_dmm_reading(char *val, uint32_t chn_indx, uint32_t dev_indx);

--- a/pocket_lab/resources/adi_logo.c
+++ b/pocket_lab/resources/adi_logo.c
@@ -581,11 +581,11 @@ const LV_ATTRIBUTE_MEM_ALIGN LV_ATTRIBUTE_LARGE_CONST LV_ATTRIBUTE_IMG_ADI_LOGO 
 };
 
 const lv_img_dsc_t adi_logo = {
-  .header.cf = LV_IMG_CF_TRUE_COLOR,
+  .header.cf = LV_COLOR_FORMAT_RGB565,
   .header.always_zero = 0,
   .header.reserved = 0,
   .header.w = 250,
   .header.h = 136,
-  .data_size = 34000 * LV_COLOR_SIZE / 8,
+  .data_size = 34000 * LV_COLOR_DEPTH / 8,
   .data = adi_logo_map,
 };


### PR DESCRIPTION
1. Removed dependency on the attribute location/index from GUI dropdown list to read/write attributes, as this creates issues reading available attributes. available attributes are not stored into GUI dropdown list, so indexing them results into reading of some other attribute and not the intended one. All attributes are now read/write by passing there name from GUI layer and then finding the matching name into attribute params structure into IIO wrapper layer
2. Updated lvgl function calls and variables related to object event set, keypad button matrix and lvgl image array as lvgl library commit is bumped up to latest lvgl library version (master branch). This is most likely going to be next stable version of lvgl library and hence changes are needed. Again, in order to support latest changes from vendor lvgl port code (stm32f769ni_disco_lvgl) the master branch verison of lvgl library needs to be used