### PR TITLE
Pocket lab updates

### DIFF
--- a/fft/adi_fft.c
+++ b/fft/adi_fft.c
@@ -52,75 +52,58 @@ static arm_cfft_instance_f32 cfft_instance;
  * @return 0 in case of success, negative error code otherwise
  */
 int adi_fft_init(struct adi_fft_init_params *param,
-		 struct adi_fft_processing **fft_proc,
-		 struct adi_fft_measurements **fft_meas)
+		 struct adi_fft_processing *fft_proc,
+		 struct adi_fft_measurements *fft_meas)
 {
-	struct adi_fft_processing *fft_proc_init;
-	struct adi_fft_measurements *fft_meas_init;
 	uint8_t cnt;
 
 	if (!param || !fft_proc || !fft_meas)
 		return -EINVAL;
 
-	fft_proc_init = (struct adi_fft_processing *)malloc(sizeof(*fft_proc_init));
-	if (!fft_proc_init)
-		return -ENOMEM;
-
-	fft_meas_init = (struct adi_fft_measurements *)malloc(sizeof(
-				*fft_meas_init));
-	if (!fft_meas_init) {
-		free(fft_proc_init);
-		return -ENOMEM;
-	}
-
-	fft_proc_init->vref = param->vref;
-	fft_proc_init->sample_rate = param->sample_rate;
-	fft_proc_init->input_data_full_scale = param->input_data_full_scale;
-	fft_proc_init->input_data_zero_scale = param->input_data_zero_scale;
-	fft_proc_init->cnv_data_to_volt_without_vref =
+	fft_proc->vref = param->vref;
+	fft_proc->sample_rate = param->sample_rate;
+	fft_proc->input_data_full_scale = param->input_data_full_scale;
+	fft_proc->input_data_zero_scale = param->input_data_zero_scale;
+	fft_proc->cnv_data_to_volt_without_vref =
 		param->convert_data_to_volt_without_vref;
-	fft_proc_init->cnv_data_to_volt_wrt_vref = param->convert_data_to_volt_wrt_vref;
-	fft_proc_init->cnv_code_to_straight_binary =
+	fft_proc->cnv_data_to_volt_wrt_vref = param->convert_data_to_volt_wrt_vref;
+	fft_proc->cnv_code_to_straight_binary =
 		param->convert_code_to_straight_binary;
-	fft_proc_init->fft_length = param->samples_count / 2;
-	fft_proc_init->window = BLACKMAN_HARRIS_7TERM;
-	fft_proc_init->bin_width = 0.0;
-	fft_proc_init->fft_done = false;
+	fft_proc->fft_length = param->samples_count / 2;
+	fft_proc->window = BLACKMAN_HARRIS_7TERM;
+	fft_proc->bin_width = 0.0;
+	fft_proc->fft_done = false;
 
-	*fft_proc = fft_proc_init;
-
-	fft_meas_init->fundamental = 0.0;
-	fft_meas_init->pk_spurious_noise = 0.0;
-	fft_meas_init->pk_spurious_freq = 0;
-	fft_meas_init->THD = 0.0;
-	fft_meas_init->SNR = 0.0;
-	fft_meas_init->DR = 0.0;
-	fft_meas_init->SINAD = 0.0;
-	fft_meas_init->SFDR_dbc = 0.0;
-	fft_meas_init->SFDR_dbfs = 0.0;
-	fft_meas_init->ENOB = 0.0;
-	fft_meas_init->RMS_noise = 0.0;
-	fft_meas_init->average_bin_noise = 0.0;
-	fft_meas_init->max_amplitude = 0.0;
-	fft_meas_init->min_amplitude = 0.0;
-	fft_meas_init->pk_pk_amplitude = 0.0;
-	fft_meas_init->DC = 0.0;
-	fft_meas_init->transition_noise = 0.0;
-	fft_meas_init->max_amplitude_LSB = 0;
-	fft_meas_init->min_amplitude_LSB = 0;
-	fft_meas_init->pk_pk_amplitude_LSB = 0;
-	fft_meas_init->DC_LSB = 0;
-	fft_meas_init->transition_noise_LSB = 0.0;
+	fft_meas->fundamental = 0.0;
+	fft_meas->pk_spurious_noise = 0.0;
+	fft_meas->pk_spurious_freq = 0;
+	fft_meas->THD = 0.0;
+	fft_meas->SNR = 0.0;
+	fft_meas->DR = 0.0;
+	fft_meas->SINAD = 0.0;
+	fft_meas->SFDR_dbc = 0.0;
+	fft_meas->SFDR_dbfs = 0.0;
+	fft_meas->ENOB = 0.0;
+	fft_meas->RMS_noise = 0.0;
+	fft_meas->average_bin_noise = 0.0;
+	fft_meas->max_amplitude = 0.0;
+	fft_meas->min_amplitude = 0.0;
+	fft_meas->pk_pk_amplitude = 0.0;
+	fft_meas->DC = 0.0;
+	fft_meas->transition_noise = 0.0;
+	fft_meas->max_amplitude_LSB = 0;
+	fft_meas->min_amplitude_LSB = 0;
+	fft_meas->pk_pk_amplitude_LSB = 0;
+	fft_meas->DC_LSB = 0;
+	fft_meas->transition_noise_LSB = 0.0;
 
 	for (cnt = 0; cnt < ADI_FFT_NUM_OF_TERMS; cnt++) {
-		fft_meas_init->harmonics_mag_dbfs[cnt] = 0.0;
-		fft_meas_init->harmonics_freq[cnt] = 0;
-		fft_meas_init->harmonics_power[cnt] = 0.0;
+		fft_meas->harmonics_mag_dbfs[cnt] = 0.0;
+		fft_meas->harmonics_freq[cnt] = 0;
+		fft_meas->harmonics_power[cnt] = 0.0;
 	}
 
-	*fft_meas = fft_meas_init;
-
-	return arm_cfft_init_f32(&cfft_instance, fft_proc_init->fft_length);
+	return arm_cfft_init_f32(&cfft_instance, fft_proc->fft_length);
 }
 
 /**

--- a/fft/adi_fft.h
+++ b/fft/adi_fft.h
@@ -25,8 +25,10 @@
 /************************ Macros/Constants ************************************/
 /******************************************************************************/
 
-/* Maximum number of samples used for FFT analysis (<=4096) */
-#define ADI_FFT_MAX_SAMPLES		4096
+/* Maximum number of default samples used for FFT analysis (<=2048) */
+#if !defined(ADI_FFT_MAX_SAMPLES)
+#define ADI_FFT_MAX_SAMPLES		2048
+#endif
 
 /******************************************************************************/
 /************************ Public Declarations *********************************/
@@ -83,10 +85,6 @@ struct adi_fft_processing {
 	float bin_width;
 	/* Input data (unformatted/straight binary for ADCs) */
 	int32_t input_data[ADI_FFT_MAX_SAMPLES];
-	/* Codes shifted up by ZERO SCALE */
-	int32_t zero_scale_codes[ADI_FFT_MAX_SAMPLES];
-	/* Voltage equivalent to input data */
-	float voltage[ADI_FFT_MAX_SAMPLES];
 	/* Maximum length of FFT magnitude */
 	float fft_magnitude[ADI_FFT_MAX_SAMPLES / 2];
 	/* Magnitude with windowing correction */
@@ -157,8 +155,8 @@ struct adi_fft_measurements {
 };
 
 int adi_fft_init(struct adi_fft_init_params *param,
-		 struct adi_fft_processing **fft_proc,
-		 struct adi_fft_measurements **fft_meas);
+		 struct adi_fft_processing *fft_proc,
+		 struct adi_fft_measurements *fft_meas);
 int adi_fft_update_params(struct adi_fft_init_params *param,
 			  struct adi_fft_processing *fft_proc);
 int adi_fft_perform(struct adi_fft_processing *fft_proc,

--- a/pocket_lab/pl_gui_events.c
+++ b/pocket_lab/pl_gui_events.c
@@ -123,7 +123,6 @@ int32_t pl_gui_event_read(uint8_t *buf, uint32_t len)
 					cnt++;
 				}
 
-				/* Get total bytes based on the fixed samples count */
 				pl_gui_nb_data_bytes *= get_data_samples_count();
 
 				sprintf(pl_gui_cmd_str, "OPEN iio:device%d %d %08x\r\n",

--- a/pocket_lab/pl_gui_events.c
+++ b/pocket_lab/pl_gui_events.c
@@ -124,10 +124,10 @@ int32_t pl_gui_event_read(uint8_t *buf, uint32_t len)
 				}
 
 				/* Get total bytes based on the fixed samples count */
-				pl_gui_nb_data_bytes *= PL_GUI_REQ_DATA_SAMPLES;
+				pl_gui_nb_data_bytes *= get_data_samples_count();
 
 				sprintf(pl_gui_cmd_str, "OPEN iio:device%d %d %08x\r\n",
-					dev_indx, PL_GUI_REQ_DATA_SAMPLES, chn_mask);
+					dev_indx, get_data_samples_count(), chn_mask);
 				pl_gui_cmd_formed = true;
 				break;
 

--- a/pocket_lab/pl_gui_iio_wrapper.c
+++ b/pocket_lab/pl_gui_iio_wrapper.c
@@ -614,7 +614,7 @@ int32_t pl_gui_get_dmm_reading(char *val, uint32_t chn_indx, uint32_t dev_indx)
 		return -EIO;
 	}
 
-	dmm_reading = ((raw + offset) * scale) / 1000.0;
+	dmm_reading = ((int32_t)(raw + offset) * scale) / 1000.0;
 	sprintf(val, "%f", dmm_reading);
 
 	return 0;

--- a/pocket_lab/pl_gui_iio_wrapper.c
+++ b/pocket_lab/pl_gui_iio_wrapper.c
@@ -229,7 +229,7 @@ int32_t pl_gui_get_global_attr_avail_options(const char *attr_name,
 		char *attr_val, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	char buf[100];
 	uint32_t attr_indx;
 	bool found = false;
@@ -274,7 +274,7 @@ int32_t pl_gui_get_chn_attr_avail_options(const char *attr_name,
 		char *attr_val, uint32_t chn_indx, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	char buf[100];
 	uint32_t attr_indx;
 	bool found = false;
@@ -322,7 +322,7 @@ int32_t pl_gui_read_global_attr(const char *attr_name, char *attr_val,
 				uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
 	char buf[50];
 
@@ -363,7 +363,7 @@ int32_t pl_gui_read_chn_attr(char *attr_name, char *attr_val,
 			     uint32_t chn_indx, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
 	char buf[50];
 
@@ -408,7 +408,7 @@ int32_t pl_gui_write_global_attr(const char *attr_name, char *attr_val,
 				 uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
 	char buf[50];
 
@@ -450,7 +450,7 @@ int32_t pl_gui_write_chn_attr(const char *attr_name, char *attr_val,
 			      uint32_t chn_indx, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
 	char buf[50];
 
@@ -538,7 +538,7 @@ int32_t pl_gui_write_reg(uint32_t addr, uint32_t data, uint32_t dev_indx)
 int32_t pl_gui_get_dmm_reading(char *val, uint32_t chn_indx, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
-	struct iio_ch_info chn_info;
+	struct iio_ch_info chn_info = { 0 };
 	char buf[50];
 	int32_t offset = 0;
 	uint32_t raw = 0;

--- a/pocket_lab/pl_gui_iio_wrapper.c
+++ b/pocket_lab/pl_gui_iio_wrapper.c
@@ -64,7 +64,7 @@ int32_t pl_gui_save_dev_param_desc(struct iio_init_param *param)
 int32_t pl_gui_get_dev_names(char *dev_names)
 {
 	uint32_t cnt;
-	char temp[50];
+	char temp[100];
 
 	if (!dev_names || !pl_gui_iio_init_params) {
 		return -EINVAL;
@@ -91,7 +91,7 @@ int32_t pl_gui_get_chn_names(char *chn_names, uint32_t *nb_of_chn,
 {
 	struct iio_device *iio_dev;
 	uint32_t chn_indx;
-	char temp[50];
+	char temp[100];
 
 	if (!pl_gui_iio_init_params || !chn_names || !nb_of_chn
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)) {
@@ -166,7 +166,7 @@ int32_t pl_gui_get_global_attr_names(char *attr_names, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
 	uint32_t cnt;
-	char temp[50];
+	char temp[100];
 
 	if (!pl_gui_iio_init_params || !attr_names
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)) {
@@ -197,7 +197,7 @@ int32_t pl_gui_get_chn_attr_names(char *attr_names, uint32_t chn_indx,
 {
 	struct iio_device *iio_dev;
 	uint32_t cnt;
-	char temp[50];
+	char temp[100];
 
 	if (!pl_gui_iio_init_params || !attr_names
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)
@@ -286,6 +286,8 @@ int32_t pl_gui_get_chn_attr_avail_options(const char *attr_name,
 		return -EINVAL;
 	}
 
+	chn_info.ch_num = chn_indx;
+
 	/* Get IIO channel names and store into string array */
 	iio_dev = pl_gui_iio_init_params->devs[dev_indx].dev_descriptor;
 	for (attr_indx = 0; iio_dev->channels[chn_indx].attributes[attr_indx].name;
@@ -324,7 +326,7 @@ int32_t pl_gui_read_global_attr(const char *attr_name, char *attr_val,
 	struct iio_device *iio_dev;
 	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
-	char buf[50];
+	char buf[100];
 
 	if (!pl_gui_iio_init_params || !attr_name || !attr_val
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)) {
@@ -365,7 +367,7 @@ int32_t pl_gui_read_chn_attr(char *attr_name, char *attr_val,
 	struct iio_device *iio_dev;
 	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
-	char buf[50];
+	char buf[100];
 
 	if (!pl_gui_iio_init_params || !attr_name || !attr_val
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)
@@ -410,7 +412,7 @@ int32_t pl_gui_write_global_attr(const char *attr_name, char *attr_val,
 	struct iio_device *iio_dev;
 	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
-	char buf[50];
+	char buf[100];
 
 	if (!pl_gui_iio_init_params || !attr_name || !attr_val
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)) {
@@ -452,7 +454,7 @@ int32_t pl_gui_write_chn_attr(const char *attr_name, char *attr_val,
 	struct iio_device *iio_dev;
 	struct iio_ch_info chn_info = { 0 };
 	uint32_t attr_indx;
-	char buf[50];
+	char buf[100];
 
 	if (!pl_gui_iio_init_params || !attr_name || !attr_val
 	    || (dev_indx >= pl_gui_iio_init_params->nb_devs)
@@ -539,7 +541,7 @@ int32_t pl_gui_get_dmm_reading(char *val, uint32_t chn_indx, uint32_t dev_indx)
 {
 	struct iio_device *iio_dev;
 	struct iio_ch_info chn_info = { 0 };
-	char buf[50];
+	char buf[100];
 	int32_t offset = 0;
 	uint32_t raw = 0;
 	uint32_t attr_indx;

--- a/pocket_lab/pl_gui_views.c
+++ b/pocket_lab/pl_gui_views.c
@@ -217,7 +217,7 @@ uint32_t pl_gui_get_active_device_index(void)
 static void pl_gui_read_and_display_attr(void)
 {
 	int32_t ret;
-	char ibuf[50], obuf[100];
+	char ibuf[100], obuf[100];
 	uint32_t chn_pos;
 
 	/* Read channel type */
@@ -293,7 +293,7 @@ static void pl_gui_read_and_display_attr(void)
 static void pl_gui_update_and_readback_attr(void)
 {
 	int32_t ret;
-	char ibuf[50];
+	char ibuf[100];
 	uint32_t chn_pos;
 	const char *text;
 
@@ -349,7 +349,7 @@ static void pl_gui_update_and_readback_attr(void)
 static void pl_gui_read_and_display_reg_val(uint32_t reg_addr)
 {
 	uint32_t reg_data = 0;
-	char ibuf[50];
+	char ibuf[100];
 
 	/* Save register address value into it's text area */
 	ibuf[0] = '\0';
@@ -387,7 +387,7 @@ void pl_gui_perform_dmm_read(void)
 	int32_t ret;
 	static uint32_t read_cntr;
 	uint32_t cnt;
-	char ibuf[50];
+	char ibuf[100];
 
 	read_cntr++;
 	if (read_cntr > PL_GUI_DMM_READ_CNT) {
@@ -430,7 +430,7 @@ static void pl_gui_rescale_data(int32_t *data)
  */
 void pl_gui_display_captured_data(uint8_t *buf, uint32_t rec_bytes)
 {
-	char obuf[50];
+	char obuf[100];
 	uint32_t chn;
 	uint32_t indx = 0;
 	uint32_t storage_bytes;
@@ -691,7 +691,7 @@ static void pl_gui_chn_select_event_cb(lv_event_t *event)
 {
 	lv_event_code_t code = lv_event_get_code(event);
 	lv_obj_t *obj = lv_event_get_target(event);
-	char ibuf[50], obuf[100];
+	char ibuf[100], obuf[100];
 	uint32_t chn_pos;
 
 	if (code == LV_EVENT_VALUE_CHANGED) {
@@ -769,7 +769,7 @@ static void pl_gui_attr_write_btn_event_cb(lv_event_t *event)
  */
 static void pl_gui_attr_avl_select_event_cb(lv_event_t *event)
 {
-	char ibuf[50];
+	char ibuf[100];
 	lv_event_code_t code = lv_event_get_code(event);
 	lv_obj_t *obj = lv_event_get_target(event);
 
@@ -1188,7 +1188,7 @@ int32_t pl_gui_create_attributes_view(lv_obj_t *parent,
 int32_t pl_gui_create_register_view(lv_obj_t *parent,
 				    struct pl_gui_init_param *param)
 {
-	char dropdown_list[50];
+	char dropdown_list[100];
 	int32_t ret;
 
 	/* Get device names */
@@ -1335,7 +1335,7 @@ int32_t pl_gui_create_dmm_view(lv_obj_t *parent,
 	char dropdown_list[100];
 	char chn_name[10];
 	char chn_unit[10];
-	char label_str[30];
+	char label_str[50];
 	uint32_t cnt;
 	uint32_t i=0, j=0;
 	uint32_t row_height;
@@ -1488,8 +1488,8 @@ int32_t pl_gui_create_capture_view(lv_obj_t *parent,
 	uint32_t cnt;
 	char dropdown_list[100];
 	char chn_name[10];
-	char label_str[30];
-	char ibuf[50];
+	char label_str[50];
+	char ibuf[100];
 	uint32_t i = 0, j = 0;
 	lv_obj_t *obj;
 	lv_obj_t *start_btn, *enable_all_btn, *disable_all_btn;

--- a/pocket_lab/pl_gui_views.h
+++ b/pocket_lab/pl_gui_views.h
@@ -108,9 +108,10 @@ int32_t pl_gui_create_dmm_view(lv_obj_t* parent,
 int32_t pl_gui_create_capture_view(lv_obj_t* parent,
 				   struct pl_gui_init_param *param);
 int32_t pl_gui_create_analysis_view(lv_obj_t* parent,
-			       struct pl_gui_init_param *param);
+				    struct pl_gui_init_param *param);
 int32_t pl_gui_create_about_view(lv_obj_t* parent,
 				 struct pl_gui_init_param *param);
+uint32_t get_data_samples_count(void);
 void pl_gui_get_capture_chns_mask(uint32_t *chn_mask);
 void pl_gui_display_captured_data(uint8_t *buf, uint32_t rec_bytes);
 bool pl_gui_is_dmm_running(void);


### PR DESCRIPTION
  pocket_lab: Bumped up stack size for string variables
  Increased the stack size of variables dealing with attribute read/write
  to 100 bytes from 50 bytes to avoid potential issue with less memory
  to store attribute related strings

  pocket_lab: Fixed issue with attribute reading
  Device attribute getter/setter APIs have extra argument of channel info
  which is not applicable for device specific attributes but has been
  utilized in IIO app layer/firmware for having common API implementation
  for both channel and device attribute getter/setters. This is why
  channel info local structure variable is explicitly initialized with 0

  pocket_lab: Fixed issue with DMM measurements
  Added missing integer typecasting for intger and non-integer
  numbers arithmetic

  pocket_lab: Fixed the issue with handling FFT samples size
  1. Number of FFT samples are processed from FFT init parameter structures supplied
  through application layer. Earlier default sample size was used for processing the data
  2. Changed fft processing and measurement structures from pointer to variables
  so that memory is allocated from RAM rather than heap. Heap allocation results
  into run time failures as FFT structures are huge in size

  fft: Removed heap (dynamic memory) dependency in fft library
  1. Removed the heap allocation for FFT parameters structures from library.
  The fft parameter structues are of length equal to number of FFT samples.
  Allocating such a huge memory from heap results into run time failures
  when heap memory run out of space. Memory to these structures is allocated
  from application layer, which could be either heap or just RAM.
  2. Reduced the max default FFT samples size to 2048 as few existing FW
  applications already consumes huge amount of memory and so no sufficient
  memory is left for FFT parameters storage. Also, the condition check has been
  added for the macro so that FFT samples size selection can be done from
  build system
