### PR TITLE
common: Add a function to free context attributes array

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -16,6 +16,7 @@
 
 #include "common.h"
 #include "board_info.h"
+#include "no_os_alloc.h"
 #if defined (TARGET_SDP_K1)
 #include "sdp_k1_sdram.h"
 #endif
@@ -280,6 +281,25 @@ int32_t get_iio_context_attributes(struct iio_ctx_attr **ctx_attr,
 	num_of_context_attributes = cnt;
 	*ctx_attr = context_attributes;
 	*attrs_cnt = num_of_context_attributes;
+
+	return 0;
+}
+
+/**
+ * @brief	Free the resources allocated by get_iio_context_attributes()
+ * @param 	ctx_attr[in] - Pointer to IIO context attributes init param
+ * @return	0 in case of success, negative error code otherwise
+ */
+int32_t remove_iio_context_attributes(struct iio_ctx_attr *ctx_attr)
+{
+	if (!ctx_attr) {
+		return -EINVAL;
+	}
+
+	/* Free the allocated context attributes array */
+	no_os_free(ctx_attr);
+
+	ctx_attr = NULL;
 
 	return 0;
 }

--- a/common/common.h
+++ b/common/common.h
@@ -57,6 +57,7 @@ int32_t get_iio_context_attributes(struct iio_ctx_attr **ctx_attr,
 				   struct no_os_eeprom_desc *eeprom_desc,
 				   const char *hw_mezzanine, const char *hw_carrier,
 				   bool *hw_mezzanine_is_valid);
+int32_t remove_iio_context_attributes(struct iio_ctx_attr *ctx_attr);
 int32_t eeprom_init(struct no_os_eeprom_desc **eeprom_desc,
 		    struct no_os_eeprom_init_param *eeprom_init_params);
 uint8_t get_eeprom_detected_dev_addr(void);


### PR DESCRIPTION
Add remove_iio_context_attributes() function to free the memory allocated while reading the context attributes