### PR TITLE
common: Add context attribute for firmware version

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -57,6 +57,12 @@ int32_t get_iio_context_attributes(struct iio_ctx_attr **ctx_attr,
 				   struct no_os_eeprom_desc *eeprom_desc,
 				   const char *hw_mezzanine, const char *hw_carrier,
 				   bool *hw_mezzanine_is_valid);
+int32_t get_iio_context_attributes_ex(struct iio_ctx_attr **ctx_attr,
+				      uint32_t *attrs_cnt,
+				      struct no_os_eeprom_desc *eeprom_desc,
+				      const char *hw_mezzanine, const char *hw_carrier,
+				      bool *hw_mezzanine_is_valid,
+				      const char *fw_version);
 int32_t remove_iio_context_attributes(struct iio_ctx_attr *ctx_attr);
 int32_t eeprom_init(struct no_os_eeprom_desc **eeprom_desc,
 		    struct no_os_eeprom_init_param *eeprom_init_params);


### PR DESCRIPTION
Add get_iio_context_attributes_ex function with
fw_version support.