### PR TITLE
board_info: include stdio.h for sprintf

### DIFF
--- a/board_info/board_info.c
+++ b/board_info/board_info.c
@@ -41,6 +41,7 @@
 /******************************************************************************/
 
 #include <stdbool.h>
+#include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
 


### PR DESCRIPTION
## Description

`board_info.c` calls `sprintf()` in `read_and_parse_sdp_eeprom()` but never includes `<stdio.h>`, relying on a transitive include from another header.

Under GCC 14+, `-Wimplicit-function-declaration` is promoted to a hard error, so consumers building this library with a recent toolchain fail with:

```
board_info/board_info.c:175:25: error: implicit declaration of function 'sprintf' [-Wimplicit-function-declaration]
```

This surfaced building the no-OS `admt4000` STM32 project (which vendors this library as a submodule) with the STM32CubeIDE 2.1.1 toolchain (arm-none-eabi-gcc 14.3.1).

## Change

Add the missing `#include <stdio.h>`. One line, no behavioral change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)